### PR TITLE
Set CMake 3.5 as minimal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.5)
 
 project(ring_buffer LANGUAGES CXX)
 


### PR DESCRIPTION
I think, as your CMake config doesn't uses super-new features are unique to latest CMake versions, why not to support older versions? Require newer CMake when you are using features of it are will not work in older CMake-s.

Also, at me system GCC-5.4 doesn't supports C++17, but supports C++14. Configure is fails when C++17 is set, however, works perfect when C++14 is toggled here. Why not to detect C++17 support or even just rely on GCC version to specify C++ standard available since specific version.
For that I'll create an issue.